### PR TITLE
feat: silence warnings for unknown STAR file labels

### DIFF
--- a/src/metadata_table.cpp
+++ b/src/metadata_table.cpp
@@ -1060,7 +1060,7 @@ long int MetaDataTable::readStarLoop(std::ifstream& in, bool do_only_count)
 
 			if (label == EMDL_UNDEFINED)
 			{
-				std::cerr << " + WARNING: will ignore (but maintain) values for the unknown label: " << token << std::endl;
+				//std::cerr << " + WARNING: will ignore (but maintain) values for the unknown label: " << token << std::endl;
 				label = EMDL_UNKNOWN_LABEL;
 			}
 
@@ -1162,7 +1162,7 @@ bool MetaDataTable::readStarList(std::ifstream& in)
 				label = EMDL_UNKNOWN_LABEL;
 				addLabel(label, token);
 				setUnknownValue(labelPosition, value);
-				std::cerr << " + WARNING: will ignore (but maintain) values for the unknown label: " << token << std::endl;
+				//std::cerr << " + WARNING: will ignore (but maintain) values for the unknown label: " << token << std::endl;
 			}
 			else
 			{


### PR DESCRIPTION
## Summary
- Comment out the two `std::cerr` warnings in `metadata_table.cpp` that print "will ignore (but maintain) values for the unknown label"
- New labels introduced by particle picker and motion correction are not recognised by other RELION programs, causing these warnings to fill up logs in jobs that read those STAR files (e.g. motion refinement)
- Unknown labels are still correctly handled and preserved in output — only the noisy stderr warnings are silenced

