### PR TITLE
feat(CRYO-XXX): add loss term evaluation and logging in motion estimation

### DIFF
--- a/src/jaz/single_particle/motion/gp_motion_fit.cpp
+++ b/src/jaz/single_particle/motion/gp_motion_fit.cpp
@@ -156,6 +156,81 @@ double GpMotionFit::f(const std::vector<double> &x) const
 	return e_tot;
 }
 
+GpMotionFit::LossTerms GpMotionFit::evaluateLossTerms(const std::vector<double> &x) const
+{
+	std::vector<std::vector<d2Vector>> pos(pc, std::vector<d2Vector>(fc));
+	paramsToPos(x, pos);
+
+	const int pad = 512;
+	std::vector<double> data_t(pad * threads, 0.0);
+	std::vector<double> vel_t(pad * threads, 0.0);
+	std::vector<double> acc_t(pad * threads, 0.0);
+
+#pragma omp parallel for num_threads(threads)
+	for (int p = 0; p < pc; p++)
+	{
+		const int t = omp_get_thread_num();
+
+		for (int f = 0; f < fc; f++)
+		{
+			data_t[pad*t] -= Interpolation::cubicXY(
+				correlation[p][f],
+				cc_pad * (pos[p][f].x + perFrameOffsets[f].x),
+				cc_pad * (pos[p][f].y + perFrameOffsets[f].y),
+				0, 0, true);
+		}
+	}
+
+#pragma omp parallel for num_threads(threads)
+	for (int f = 0; f < fc-1; f++)
+	{
+		const int t = omp_get_thread_num();
+
+		for (int d = 0; d < dc; d++)
+		{
+			const double cx = x[2*(pc + dc*f + d)    ];
+			const double cy = x[2*(pc + dc*f + d) + 1];
+
+			vel_t[pad*t] += cx*cx + cy*cy;
+		}
+	}
+
+	if (sig_acc_px > 0.0)
+	{
+#pragma omp parallel for num_threads(threads)
+		for (int f = 0; f < fc-2; f++)
+		{
+			const int t = omp_get_thread_num();
+
+			for (int d = 0; d < dc; d++)
+			{
+				const double cx0 = x[2*(pc + dc*f + d)    ];
+				const double cy0 = x[2*(pc + dc*f + d) + 1];
+				const double cx1 = x[2*(pc + dc*(f+1) + d)    ];
+				const double cy1 = x[2*(pc + dc*(f+1) + d) + 1];
+
+				const double dcx = cx1 - cx0;
+				const double dcy = cy1 - cy0;
+
+				acc_t[pad*t] += eigenVals[d]*(dcx*dcx + dcy*dcy) / (sig_acc_px*sig_acc_px);
+			}
+		}
+	}
+
+	LossTerms terms{0.0, 0.0, 0.0, 0.0};
+
+	for (int t = 0; t < threads; t++)
+	{
+		terms.data += data_t[pad*t];
+		terms.vel_reg += vel_t[pad*t];
+		terms.acc_reg += acc_t[pad*t];
+	}
+
+	terms.total = terms.data + terms.vel_reg + terms.acc_reg;
+
+	return terms;
+}
+
 double GpMotionFit::f(const std::vector<double> &x, void* tempStorage) const
 {
 	if (tempStorage == 0) return f(x);

--- a/src/jaz/single_particle/motion/gp_motion_fit.h
+++ b/src/jaz/single_particle/motion/gp_motion_fit.h
@@ -30,6 +30,14 @@ class GpMotionFit : public DifferentiableOptimization
 {
     public:
 
+		struct LossTerms
+		{
+			double data;
+			double vel_reg;
+			double acc_reg;
+			double total;
+		};
+
         GpMotionFit(
                 const std::vector<std::vector<Image<double>>>& correlation,
                 double cc_pad,
@@ -41,6 +49,7 @@ class GpMotionFit : public DifferentiableOptimization
 
         double f(const std::vector<double>& x) const;
         double f(const std::vector<double>& x, void* tempStorage) const;
+		LossTerms evaluateLossTerms(const std::vector<double>& x) const;
 
         void grad(const std::vector<double>& x, std::vector<double>& gradDest) const;
         void grad(const std::vector<double>& x, std::vector<double>& gradDest, void* tempStorage) const;

--- a/src/jaz/single_particle/motion/motion_estimator.cpp
+++ b/src/jaz/single_particle/motion/motion_estimator.cpp
@@ -36,12 +36,41 @@
 #include <src/jaz/optimization/lbfgs.h>
 #include <src/jaz/util/zio.h>
 
+#include <iomanip>
 
 using namespace gravis;
 
 MotionEstimator::MotionEstimator()
-	:   paramsRead(false), ready(false)
+	:   paramsRead(false), ready(false),
+		print_loss_terms(false), loss_logging_active(false)
 {
+}
+
+namespace
+{
+	void printLossTermsLine(
+			const std::string& micrograph_context,
+			const char* phase,
+			const GpMotionFit::LossTerms& terms)
+	{
+		std::ios::fmtflags old_flags = std::cout.flags();
+		std::streamsize old_precision = std::cout.precision();
+
+		std::cout.setf(std::ios::fixed, std::ios::floatfield);
+		std::cout.precision(8);
+
+		std::cout << " [motion_loss]"
+		          << " micrograph=" << micrograph_context
+		          << " phase=" << phase
+		          << " data=" << terms.data
+		          << " vel_reg=" << terms.vel_reg
+		          << " acc_reg=" << terms.acc_reg
+		          << " total=" << terms.total
+		          << std::endl;
+
+		std::cout.flags(old_flags);
+		std::cout.precision(old_precision);
+	}
 }
 
 void MotionEstimator::read(IOParser& parser, int argc, char *argv[])
@@ -77,6 +106,7 @@ void MotionEstimator::read(IOParser& parser, int argc, char *argv[])
 	params_scaled_by_dose = !parser.checkOption("--absolute_params", "Do not scale input motion parameters by dose");
 
 	debugOpt = parser.checkOption("--debug_opt", "Write optimization debugging info");
+	print_loss_terms = parser.checkOption("--print_loss_terms", "Print first/final per-term motion losses (data, velocity and acceleration)");
 
 	global_init = parser.checkOption("--gi", "Initialize with global trajectories instead of loading them from metadata file");
 	expKer = !parser.checkOption("--sq_exp_ker", "Use a square-exponential kernel instead of an exponential one");
@@ -109,6 +139,7 @@ void MotionEstimator::init(
 	this->obsModel = obsModel;
 	this->micrographHandler = micrographHandler;
 	angpix = obsModel->getPixelSizes();
+	loss_logging_active = print_loss_terms && (verb > 0);
 
 	s_ref = reference->s;
 	sh_ref = s_ref/2 + 1;
@@ -254,8 +285,10 @@ void MotionEstimator::process(
 
 		if (!all_groups && !obsModel->containsGroup(mdts[g], group)) continue;
 
+		const std::string fn_root = MotionRefiner::getOutputFileNameRoot(outPath, mdts[g]);
+
 		// Make sure output directory exists
-		FileName newdir = MotionRefiner::getOutputFileNameRoot(outPath, mdts[g]);
+		FileName newdir = fn_root;
 		newdir = newdir.beforeLastOf("/");
 
 		if (debug)
@@ -323,14 +356,12 @@ void MotionEstimator::process(
 			tracks = optimize(
 				movieCC, initialTracks,
 				sig_vel_px, sig_acc_px, sig_div_px,
-				positions, globComp);
+				positions, globComp, loss_logging_active, fn_root);
 		}
 		else
 		{
 			tracks = initialTracks;
 		}
-
-		std::string fn_root = MotionRefiner::getOutputFileNameRoot(outPath, mdts[g]);
 
 		bool hasNaNs = false;
 
@@ -527,7 +558,9 @@ std::vector<std::vector<d2Vector>> MotionEstimator::optimize(
 		const std::vector<std::vector<gravis::d2Vector>>& inTracks,
 		double sig_vel_px, double sig_acc_px, double sig_div_px,
 		const std::vector<gravis::d2Vector>& positions,
-		const std::vector<gravis::d2Vector>& globComp) const
+		const std::vector<gravis::d2Vector>& globComp,
+		bool log_loss_terms,
+		const std::string& loss_context) const
 {
 	if (maxIters == 0) return inTracks;
 
@@ -556,8 +589,20 @@ std::vector<std::vector<d2Vector>> MotionEstimator::optimize(
 
 	gpmf.posToParams(inTracks, initialCoeffs);
 
+	if (log_loss_terms)
+	{
+		const GpMotionFit::LossTerms terms = gpmf.evaluateLossTerms(initialCoeffs);
+		printLossTermsLine(loss_context, "initial", terms);
+	}
+
 	std::vector<double> optCoeffs = LBFGS::optimize(
 				initialCoeffs, gpmf, debugOpt, maxIters, optEps);
+
+	if (log_loss_terms)
+	{
+		const GpMotionFit::LossTerms terms = gpmf.evaluateLossTerms(optCoeffs);
+		printLossTermsLine(loss_context, "final", terms);
+	}
 
 	std::vector<std::vector<d2Vector>> out(pc, std::vector<d2Vector>(fc));
 	gpmf.paramsToPos(optCoeffs, out);
@@ -576,7 +621,9 @@ std::vector<std::vector<d2Vector>> MotionEstimator::optimize(
 		const std::vector<std::vector<gravis::d2Vector>>& inTracks,
 		double sig_vel_px, double sig_acc_px, double sig_div_px,
 		const std::vector<gravis::d2Vector>& positions,
-		const std::vector<gravis::d2Vector>& globComp) const
+		const std::vector<gravis::d2Vector>& globComp,
+		bool log_loss_terms,
+		const std::string& loss_context) const
 {
 	const int pc = movieCC.size();
 	const int fc = movieCC[0].size();
@@ -602,7 +649,8 @@ std::vector<std::vector<d2Vector>> MotionEstimator::optimize(
 		}
 	}
 
-	return optimize(CCd, inTracks, sig_vel_px, sig_acc_px, sig_div_px, positions, globComp);
+	return optimize(CCd, inTracks, sig_vel_px, sig_acc_px, sig_div_px, positions, globComp,
+	                log_loss_terms, loss_context);
 }
 
 std::vector<Image<RFLOAT>> MotionEstimator::computeDamageWeights(int opticsGroup)

--- a/src/jaz/single_particle/motion/motion_estimator.h
+++ b/src/jaz/single_particle/motion/motion_estimator.h
@@ -70,7 +70,9 @@ class MotionEstimator
             const std::vector<std::vector<gravis::d2Vector>>& inTracks,
             double sig_vel_px, double sig_acc_px, double sig_div_px,
             const std::vector<gravis::d2Vector>& positions,
-            const std::vector<gravis::d2Vector>& globComp) const;
+            const std::vector<gravis::d2Vector>& globComp,
+			bool log_loss_terms = false,
+			const std::string& loss_context = "") const;
 
         // syntactic sugar for float-valued CCs
         std::vector<std::vector<gravis::d2Vector>> optimize(
@@ -78,7 +80,9 @@ class MotionEstimator
             const std::vector<std::vector<gravis::d2Vector>>& inTracks,
             double sig_vel_px, double sig_acc_px, double sig_div_px,
             const std::vector<gravis::d2Vector>& positions,
-            const std::vector<gravis::d2Vector>& globComp) const;
+            const std::vector<gravis::d2Vector>& globComp,
+			bool log_loss_terms = false,
+			const std::string& loss_context = "") const;
 
 	std::vector<Image<RFLOAT>> computeDamageWeights(int opticsGroup);
 		
@@ -105,6 +109,7 @@ class MotionEstimator
     protected:
 
             bool paramsRead, ready;
+			bool print_loss_terms, loss_logging_active;
 
             // read from cmd line
             int maxEDs, maxIters, globOffMax, group;


### PR DESCRIPTION
- Here we introduce loss terms in the Relion log, which will make it easier to later compare it to CCMC!

- The following was compiled and tested on my macbook:
```
/Users/tadej/Repositories/cryocloud/relion/build-mac/bin/relion_motion_refine --i particles_ctf_refine.star --f postprocess.star --corr_mic corrected_micrographs.star --o relion_termloss_out --s_vel 0.2 --s_div 5000 --s_acc 2 --j 4 --print_loss_terms 2>&1 | tee relion_termloss_out/terms.log
 + Reading particles_ctf_refine.star...
 + Using movie pixel size from mics/May08_03_05_02_bin.star: 1.5 A
 + Using coord. pixel size from mics/May08_03_05_02_bin.star: 1.5 A
 - Movies for the following micrographs are missing:
       mics/May08_03_05_02_bin.mrc
       mics/May08_03_13_02_bin.mrc
       mics/May08_03_15_02_bin.mrc
       mics/May08_03_43_44_bin.mrc
       mics/May08_04_32_27_bin.mrc
       mics/May08_04_33_57_bin.mrc
 + Using dose per frame from mics/May08_03_05_02_bin.star: 2 e/A^2
 + Reading references ...
 + The names of the reference half maps and the mask were taken from the PostProcess STAR file.
   - Half map 1: run_half1_class001_unfil.mrc
   - Half map 2: run_half2_class001_unfil.mrc
   - Mask: run_class001_automask.mrc
WARNING: You did not specify --angpix_ref. The pixel size in the image header of run_half1_class001_unfil.mrc, 1.5 A/px, is used.
 + Masking references ...
 + Transforming references ...
 + Initializing motion estimator ...
 + Performing loop over micrographs ... 
000/??? sec ~~(,_,">                                                          [oo] [motion_loss] micrograph=relion_termloss_out/mics/May08_04_36_57_bin phase=initial data=-58808.31399839 vel_reg=1023.26474188 acc_reg=583.02117641 total=-57202.02808010
 [motion_loss] micrograph=relion_termloss_out/mics/May08_04_36_57_bin phase=final data=-59346.19335625 vel_reg=397.56857701 acc_reg=62.19233173 total=-58886.43244751
   3/  39 sec ....~~(,_,">                                                    [oo] [motion_loss] micrograph=relion_termloss_out/mics/May08_05_24_39_bin phase=initial data=-49156.75612972 vel_reg=2539.24113393 acc_reg=1216.96810715 total=-45400.54688864
 [motion_loss] micrograph=relion_termloss_out/mics/May08_05_24_39_bin phase=final data=-49220.51962763 vel_reg=496.79019842 acc_reg=62.97373835 total=-48660.75569087
   5/  32 sec .........~~(,_,">                                               [oo] [motion_loss] micrograph=relion_termloss_out/mics/May08_05_31_00_bin phase=initial data=-81735.92211782 vel_reg=1044.26289960 acc_reg=620.78628103 total=-80070.87293720
 [motion_loss] micrograph=relion_termloss_out/mics/May08_05_31_00_bin phase=final data=-83100.09726413 vel_reg=279.66466062 acc_reg=79.71336546 total=-82740.71923805
   7/  30 sec .............~~(,_,">                                           [oo] [motion_loss] micrograph=relion_termloss_out/mics/May08_05_35_20_bin phase=initial data=-95125.38184864 vel_reg=289.84986142 acc_reg=276.35663971 total=-94559.17534751
 [motion_loss] micrograph=relion_termloss_out/mics/May08_05_35_20_bin phase=final data=-96001.25826558 vel_reg=181.89137752 acc_reg=41.07131757 total=-95778.29557050
  10/  32 sec ..................~~(,_,">                                      [oo] [motion_loss] micrograph=relion_termloss_out/mics/May08_05_53_51_bin phase=initial data=-80576.37751439 vel_reg=242.73394166 acc_reg=312.82814911 total=-80020.81542363
 [motion_loss] micrograph=relion_termloss_out/mics/May08_05_53_51_bin phase=final data=-81479.82680134 vel_reg=168.18678432 acc_reg=23.90567907 total=-81287.73433795
  13/  33 sec .......................~~(,_,">                                 [oo] [motion_loss] micrograph=relion_termloss_out/mics/May08_05_55_31_bin phase=initial data=-68312.58369086 vel_reg=305.00850214 acc_reg=265.34906021 total=-67742.22612850
 [motion_loss] micrograph=relion_termloss_out/mics/May08_05_55_31_bin phase=final data=-68804.12437579 vel_reg=164.27230951 acc_reg=42.33644785 total=-68597.51561843
  16/  34 sec ...........................~~(,_,">                             [oo] [motion_loss] micrograph=relion_termloss_out/mics/May08_05_57_01_bin phase=initial data=-74519.91477888 vel_reg=263.83923086 acc_reg=285.82375450 total=-73970.25179353
 [motion_loss] micrograph=relion_termloss_out/mics/May08_05_57_01_bin phase=final data=-75124.31072105 vel_reg=150.89770858 acc_reg=25.88019415 total=-74947.53281833
  18/  33 sec ................................~~(,_,">                        [oo] [motion_loss] micrograph=relion_termloss_out/mics/May08_05_59_52_bin phase=initial data=-74049.31911858 vel_reg=570.51476420 acc_reg=544.00123504 total=-72934.80311934
 [motion_loss] micrograph=relion_termloss_out/mics/May08_05_59_52_bin phase=final data=-74516.33640680 vel_reg=240.17331085 acc_reg=77.09796074 total=-74199.06513521
  21/  34 sec ....................................~~(,_,">                    [oo] [motion_loss] micrograph=relion_termloss_out/mics/May08_06_30_43_bin phase=initial data=-95570.56691298 vel_reg=1186.43019082 acc_reg=499.44525733 total=-93884.69146483
 [motion_loss] micrograph=relion_termloss_out/mics/May08_06_30_43_bin phase=final data=-96329.79703842 vel_reg=586.20898084 acc_reg=103.67238952 total=-95639.91566806
  24/  34 sec .........................................~~(,_,">               [oo] [motion_loss] micrograph=relion_termloss_out/mics/May08_07_08_55_bin phase=initial data=-59806.23458074 vel_reg=1131.54395572 acc_reg=924.54080621 total=-57750.14981881
 [motion_loss] micrograph=relion_termloss_out/mics/May08_07_08_55_bin phase=final data=-60082.68779846 vel_reg=310.75713773 acc_reg=94.98425415 total=-59676.94640658
  26/  33 sec ..............................................~~(,_,">          [oo] [motion_loss] micrograph=relion_termloss_out/mics/May08_07_10_35_bin phase=initial data=-69109.94058761 vel_reg=3015.12433250 acc_reg=2245.13053862 total=-63849.68571649
 [motion_loss] micrograph=relion_termloss_out/mics/May08_07_10_35_bin phase=final data=-69565.87230522 vel_reg=412.61320217 acc_reg=156.15944238 total=-68997.09966067
  28/  33 sec ..................................................~~(,_,">      [oo] [motion_loss] micrograph=relion_termloss_out/mics/May08_07_13_35_bin phase=initial data=-64993.86799213 vel_reg=3997.35590435 acc_reg=2067.36400327 total=-58929.14808451
 [motion_loss] micrograph=relion_termloss_out/mics/May08_07_13_35_bin phase=final data=-64805.72301932 vel_reg=519.94277549 acc_reg=70.85210911 total=-64214.92813472
  31/  33 sec .......................................................~~(,_,"> [oo] [motion_loss] micrograph=relion_termloss_out/mics/May08_07_30_46_bin phase=initial data=-64102.80198951 vel_reg=2238.86280112 acc_reg=1065.95143576 total=-60797.98775264
 [motion_loss] micrograph=relion_termloss_out/mics/May08_07_30_46_bin phase=final data=-64333.02748324 vel_reg=794.90783164 acc_reg=109.28688504 total=-63428.83276657
  33/  33 sec ............................................................~~(,_,"> yum!
 + Performing loop over micrographs ... 
```