### PR TITLE
progress_bar: suppress animation when stdout is not a TTY

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,7 +210,7 @@ if(CUDA)
 elseif(HIP)
     # ------------------------------------------------------------------------------HIP--
     if (DEFINED ENV{ROCM_PATH})
-        include($ENV{ROCM_PATH}/hip/cmake/FindHIP.cmake)
+        include($ENV{ROCM_PATH}/lib/cmake/hip/FindHIP.cmake)
     elseif(DEFINED ENV{HIP_PATH})
         include($ENV{HIP_PATH}/cmake/FindHIP.cmake)
     elseif(EXISTS "${CMAKE_SOURCE_DIR}/cmake/FindHIP.cmake")

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-RELION 5.0-beta
-===============
+RELION 5.0.0
+============
 
 RELION (for REgularised LIkelihood OptimisatioN) is a stand-alone computer
 program for Maximum A Posteriori refinement of (multiple) 3D reconstructions

--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,8 @@ dependencies:
       - fastcluster==1.2.6
       - seaborn==0.12.2
       - dill==0.3.7
-      - numpy<2
+      - numpy==1.26.1
+      - scipy==1.11.2
       - git+https://github.com/3dem/relion-classranker
       - git+https://github.com/3dem/relion-blush
       - git+https://github.com/3dem/DynaMight

--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,7 @@ dependencies:
       - seaborn==0.12.2
       - dill==0.3.7
       - numpy<2
-      - git+https://github.com/3dem/relion-classranker@b6e751e5cb4205d8e9b36d0ae38c3687b3395acb
+      - git+https://github.com/3dem/relion-classranker
       - git+https://github.com/3dem/relion-blush
       - git+https://github.com/3dem/DynaMight
       - git+https://github.com/3dem/topaz

--- a/src/acc/hip/hip_fft.h
+++ b/src/acc/hip/hip_fft.h
@@ -7,7 +7,7 @@
 #include "src/acc/hip/hip_settings.h"
 #include "src/acc/hip/hip_mem_utils.h"
 #include <hip/hip_runtime.h>
-#include <hipfft.h>
+#include <hipfft/hipfft.h>
 
 #ifdef DEBUG_HIP
 #define HANDLE_HIPFFT_ERROR( err ) (HipfftHandleError( err, __FILE__, __LINE__ ))

--- a/src/acc/hip/hip_kernels/helper.h
+++ b/src/acc/hip/hip_kernels/helper.h
@@ -5,8 +5,8 @@
 #define HIP_HELPER_KERNELS_H_
 
 #include <hip/hip_runtime.h>
-#include <hiprand.h>
-#include <hiprand_kernel.h>
+#include <hiprand/hiprand.h>
+#include <hiprand/hiprand_kernel.h>
 #include <vector>
 #include <iostream>
 #include <fstream>

--- a/src/acc/hip/hip_kernels/helper.hip.cpp
+++ b/src/acc/hip/hip_kernels/helper.hip.cpp
@@ -7,8 +7,8 @@
 #include "src/acc/hip/hip_kernels/helper.h"
 #include "src/acc/hip/hip_settings.h"
 
-#include <hiprand.h>
-#include <hiprand_kernel.h>
+#include <hiprand/hiprand.h>
+#include <hiprand/hiprand_kernel.h>
 
 /// Needed explicit template instantiations
 template __global__ void hip_kernel_make_eulers_2D<true>(XFLOAT *,

--- a/src/acc/hip/hip_mem_utils.h
+++ b/src/acc/hip/hip_mem_utils.h
@@ -6,7 +6,7 @@
 
 #ifdef _HIP_ENABLED
 #include <hip/hip_runtime.h>
-#include <hiprand.h>
+#include <hiprand/hiprand.h>
 #include "src/acc/hip/hip_settings.h"
 #include "src/acc/hip/custom_allocator.h"
 #endif

--- a/src/acc/hip/hip_ml_optimiser.hip.cpp
+++ b/src/acc/hip/hip_ml_optimiser.hip.cpp
@@ -11,8 +11,8 @@
 #include <iostream>
 #include "src/ml_optimiser.h"
 #include <hip/hip_runtime.h>
-#include <hiprand.h>
-#include <hiprand_kernel.h>
+#include <hiprand/hiprand.h>
+#include <hiprand/hiprand_kernel.h>
 
 #include "src/acc/acc_ptr.h"
 #include "src/acc/acc_projector.h"

--- a/src/acc/hip/hip_settings.h
+++ b/src/acc/hip/hip_settings.h
@@ -15,7 +15,7 @@
 #include "src/macros.h"
 #include "src/error.h"
 
-#include <hiprand.h>
+#include <hiprand/hiprand.h>
 
 // Required compute capability
 #define HIP_CC_MAJOR 5

--- a/src/acc/hip/hip_utils_cub.h
+++ b/src/acc/hip/hip_utils_cub.h
@@ -39,14 +39,14 @@ if (ptr.getAllocator() == NULL)
 	max_pair.deviceAlloc();
 	size_t temp_storage_size = 0;
 
-	DEBUG_HANDLE_ERROR(hipcub::DeviceReduce::ArgMax( NULL, temp_storage_size, ~ptr, ~max_pair, ptr.getSize()));
+	DEBUG_HANDLE_ERROR(hipcub::DeviceReduce::ArgMax( NULL, temp_storage_size, ~ptr, ~max_pair, static_cast<int>(ptr.getSize())));
 
 	if(temp_storage_size==0)
 		temp_storage_size=1;
 
 	HipCustomAllocator::Alloc* alloc = ptr.getAllocator()->alloc(temp_storage_size);
 
-	DEBUG_HANDLE_ERROR(hipcub::DeviceReduce::ArgMax( alloc->getPtr(), temp_storage_size, ~ptr, ~max_pair, ptr.getSize(), ptr.getStream()));
+	DEBUG_HANDLE_ERROR(hipcub::DeviceReduce::ArgMax( alloc->getPtr(), temp_storage_size, ~ptr, ~max_pair, static_cast<int>(ptr.getSize()), ptr.getStream()));
 
 	max_pair.cpToHost();
 	ptr.streamSync();
@@ -75,14 +75,14 @@ if (ptr.getAllocator() == NULL)
 	min_pair.deviceAlloc();
 	size_t temp_storage_size = 0;
 
-	DEBUG_HANDLE_ERROR(hipcub::DeviceReduce::ArgMin( NULL, temp_storage_size, ~ptr, ~min_pair, ptr.getSize()));
+	DEBUG_HANDLE_ERROR(hipcub::DeviceReduce::ArgMin( NULL, temp_storage_size, ~ptr, ~min_pair, static_cast<int>(ptr.getSize())));
 
 	if(temp_storage_size==0)
 		temp_storage_size=1;
 
 	HipCustomAllocator::Alloc* alloc = ptr.getAllocator()->alloc(temp_storage_size);
 
-	DEBUG_HANDLE_ERROR(hipcub::DeviceReduce::ArgMin( alloc->getPtr(), temp_storage_size, ~ptr, ~min_pair, ptr.getSize(), ptr.getStream()));
+	DEBUG_HANDLE_ERROR(hipcub::DeviceReduce::ArgMin( alloc->getPtr(), temp_storage_size, ~ptr, ~min_pair, static_cast<int>(ptr.getSize()), ptr.getStream()));
 
 	min_pair.cpToHost();
 	ptr.streamSync();

--- a/src/apps/CMakeLists.txt
+++ b/src/apps/CMakeLists.txt
@@ -293,7 +293,7 @@ if (CUDA_FOUND)
 
 elseif (HIP_FOUND)
 	file(GLOB REL_HIP_SRC "${CMAKE_SOURCE_DIR}/src/acc/hip/*.cpp" "${CMAKE_SOURCE_DIR}/src/acc/hip/hip_kernels/*.cpp" )
-	hip_add_library(relion_gpu_util ${REL_HIP_SRC})
+	add_library(relion_gpu_util ${REL_HIP_SRC})
 
 	if (${CMAKE_BUILD_TYPE_LOWER} STREQUAL "profiling")
 		find_library(ROCM_TRACER_LIB NAMES roctx64 PATHS ${HIP_ROOT_DIR}/lib ${HIP_ROOT_DIR}/../lib REQUIRED)

--- a/src/apps/helix_vote_classes.cpp
+++ b/src/apps/helix_vote_classes.cpp
@@ -235,12 +235,12 @@ class helix_analyse_classes_parameters
         if (fn_groups != "")
         {
         	std::vector<std::string> groups;
-        	int numfound = splitString(fn_groups, ":", groups);
+        	splitString(fn_groups, ":", groups);
         	nr_groups = groups.size();
         	for (int igroup=0; igroup<groups.size(); igroup++)
         	{
         		std::vector<std::string> classes;
-        		int numfound = splitString(groups[igroup], ",", classes);
+        		splitString(groups[igroup], ",", classes);
 
             	for (int iclass=0; iclass<classes.size(); iclass++)
             	{
@@ -251,7 +251,7 @@ class helix_analyse_classes_parameters
 
         	if (fn_group_names != "")
         	{
-        		int numfound = splitString(fn_group_names, ":", group_names);
+        		splitString(fn_group_names, ":", group_names);
         		if (group_names.size() != nr_groups) REPORT_ERROR("ERROR: incorrect number of group names");
         	}
         	else

--- a/src/apps/star_handler.cpp
+++ b/src/apps/star_handler.cpp
@@ -316,7 +316,8 @@ class star_handler_parameters
 		std::cout << " [ Average , stddev ] of the stddev  Image value = [ " << sum_stddev<< " , " << sum2_stddev << " ] "  << std::endl;
 
 		long int i = 0, nr_discard = 0;
-		FOR_ALL_OBJECTS_IN_METADATA_TABLE(MDin)
+		MDout.setName(MDin.getName());
+        FOR_ALL_OBJECTS_IN_METADATA_TABLE(MDin)
 		{
 			if (avgs[i] > sum_avg - discard_sigma * sum2_avg &&
 			    avgs[i] < sum_avg + discard_sigma * sum2_avg &&
@@ -833,7 +834,8 @@ class star_handler_parameters
 		for (int isplit = 0; isplit < nr_split; isplit ++)
 		{
 			FileName fnt = fn_out.insertBeforeExtension("_split"+integerToString(isplit+1));
-			write_check_ignore_optics(MDouts[isplit], fnt, MD.getName());
+			MDouts[isplit].setName(MD.getName());
+            write_check_ignore_optics(MDouts[isplit], fnt, MD.getName());
 			std::cout << " Written: " <<fnt << " with " << MDouts[isplit].numberOfObjects() << " objects." << std::endl;
 
 			MDnodes.addObject();

--- a/src/assembly.cpp
+++ b/src/assembly.cpp
@@ -217,7 +217,7 @@ void Assembly::readPDB(std::string filename, bool use_segid_instead_of_chainid, 
 	fh.seekg(0);
 
 	// Loop over all lines
-	while (fh.getline (line, 600))
+	while (fh.getline (line, 100))
 	{
 		// Only look at lines with an ATOM label
 		std::string record(line,0,6);

--- a/src/ctffind_runner.cpp
+++ b/src/ctffind_runner.cpp
@@ -460,6 +460,8 @@ void CtffindRunner::joinCtffindResults()
 
 		if (verb > 0 && imic % 60 == 0) progress_bar(imic);
 	}
+	if (MDctf.isEmpty())
+		REPORT_ERROR( (std::string) fn_ctffind_exe + " failed to estimate CTF parameters for any micrograph, exiting...");
 
     if (is_tomo)
     {

--- a/src/ctffind_runner.cpp
+++ b/src/ctffind_runner.cpp
@@ -694,7 +694,7 @@ void CtffindRunner::executeCtffind4(long int imic)
 
 	// Write script to run ctffind
 	fh << "#!/usr/bin/env " << fn_shell << std::endl;
-	fh << fn_ctffind_exe << ctffind4_options << " > " << fn_log << " << EOF"<<std::endl;
+	fh << "env LC_ALL=C " << fn_ctffind_exe << ctffind4_options << " > " << fn_log << " << EOF"<<std::endl;
 	// line 1: input image
 	if (do_movie_thon_rings)
 	{

--- a/src/filename.h
+++ b/src/filename.h
@@ -64,7 +64,7 @@
 #include "src/error.h"
 #include "src/strings.h"
 
-#define FILENAMENUMBERLENGTH 6
+#define FILENAMENUMBERLENGTH 8
 
 //@{
 /** Filenames.

--- a/src/flex_analyser.cpp
+++ b/src/flex_analyser.cpp
@@ -93,7 +93,7 @@ void FlexAnalyser::initialise()
 	// This creates a rotation matrix for (rot,tilt,psi) = (0,90,0)
 	// It will be used to make all Abody orientation matrices relative to (0,90,0) instead of the more logical (0,0,0)
 	// This is useful, as psi-priors are ill-defined around tilt=0, as rot becomes the same as -psi!!
-	rotation3DMatrix(-90., 'Y', A_rot90, false);
+	rotation3DMatrix(+90., 'Y', A_rot90, false);
 	A_rot90T = A_rot90.transpose();
 
 	if (do_PCA_orient)

--- a/src/gui_jobwindow.cpp
+++ b/src/gui_jobwindow.cpp
@@ -2884,10 +2884,6 @@ void JobWindow::initialiseTomoSubtomoWindow()
     place("do_stack2d", TOGGLE_DEACTIVATE);
     place("do_float16", TOGGLE_DEACTIVATE);
 
-    current_y += STEPY /2 ;
-
-    place("do_real_subtomo", TOGGLE_DEACTIVATE);
-
 	tab2->end();
 }
 

--- a/src/gui_jobwindow.cpp
+++ b/src/gui_jobwindow.cpp
@@ -2747,8 +2747,8 @@ void JobWindow::initialiseTomoReconstructTomogramsWindow()
 
     current_y += STEPY /2 ;
 
-    place ("tiltangle_offset");
-    place("tomo_name", TOGGLE_REACTIVATE);
+    place ("tiltangle_offset", TOGGLE_DEACTIVATE);
+    place("tomo_name");
 
     current_y += STEPY /2 ;
 

--- a/src/helix.cpp
+++ b/src/helix.cpp
@@ -47,14 +47,14 @@ void makeHelicalSymmetryList(
 		rise_samplings = ROUND(fabs(rise_max_pix - rise_min_pix) / fabs(rise_step_pix));
 	else
 	{
-		rise_min_pix = (rise_min_pix + rise_max_pix) / 2.;
+		rise_min_pix = (rise_min_pix + rise_max_pix) * 0.5;
 		rise_samplings = 0;
 	}
 	if (search_twist)
 		twist_samplings = ROUND(fabs(twist_max_deg - twist_min_deg) / fabs(twist_step_deg));
 	else
 	{
-		twist_min_deg = (twist_min_deg + twist_max_deg) / 2.;
+		twist_min_deg = (twist_min_deg + twist_max_deg) * 0.5;
 		twist_samplings = 0;
 	}
 
@@ -82,8 +82,8 @@ void makeHelicalSymmetryList(
 
 			twist_dev_deg = fabs(list[ii].twist_deg - tmp_list[jj].twist_deg);
 			rise_dev_pix = fabs(list[ii].rise_pix - tmp_list[jj].rise_pix);
-			twist_avg_deg = (fabs(list[ii].twist_deg) + fabs(tmp_list[jj].twist_deg)) / 2.;
-			rise_avg_pix = (fabs(list[ii].rise_pix) + fabs(tmp_list[jj].rise_pix)) / 2.;
+			twist_avg_deg = (fabs(list[ii].twist_deg) + fabs(tmp_list[jj].twist_deg)) * 0.5;
+			rise_avg_pix = (fabs(list[ii].rise_pix) + fabs(tmp_list[jj].rise_pix)) * 0.5;
 
 			if (twist_avg_deg < err_max)
 			{
@@ -319,8 +319,8 @@ bool localSearchHelicalSymmetry(
 
 	// Initialise refined helical parameters
 	// Check helical parameters
-	rise_refined_A = (rise_min_A + rise_max_A) / 2.;
-	twist_refined_deg = (twist_min_deg + twist_max_deg) / 2.;
+	rise_refined_A = (rise_min_A + rise_max_A) * 0.5;
+	twist_refined_deg = (twist_min_deg + twist_max_deg) * 0.5;
 	checkParametersFor3DHelicalReconstruction(
 			false,
 			true,
@@ -388,7 +388,7 @@ bool localSearchHelicalSymmetry(
 	}
 
 	rise_inistep_pix = (rise_inistep_pix < (1e-5)) ? (1e30) : (rise_inistep_pix);
-	rise_step_pix = 0.01 * ((fabs(rise_local_min_pix) + fabs(rise_local_max_pix)) / 2.);
+	rise_step_pix = 0.01 * ((fabs(rise_local_min_pix) + fabs(rise_local_max_pix)) * 0.5);
 	rise_step_pix = (rise_step_pix < rise_inistep_pix) ? (rise_step_pix) : (rise_inistep_pix);
 	nr_rise_samplings = CEIL(fabs(rise_local_min_pix - rise_local_max_pix) / rise_step_pix);
 	nr_rise_samplings = (nr_rise_samplings > nr_min_samplings) ? (nr_rise_samplings) : (nr_min_samplings);
@@ -590,9 +590,9 @@ bool localSearchHelicalSymmetry(
 
 		// Decrease step size
 		if (search_rise)
-			rise_step_pix /= 2.;
+			rise_step_pix *= 0.5;
 		if (search_twist)
-			twist_step_deg /= 2.;
+			twist_step_deg *= 0.5;
 	}
 
 	if (out_of_range)
@@ -748,8 +748,8 @@ bool checkParametersFor3DHelicalReconstruction(
 		twist_min_deg = twist_max_deg = twist_initial_deg;
 		rise_min_A = rise_max_A = rise_initial_A;
 	}
-	RFLOAT rise_avg_A = (rise_min_A + rise_max_A) / 2.;
-	RFLOAT twist_avg_deg = (twist_min_deg + twist_max_deg) / 2.;
+	RFLOAT rise_avg_A = (rise_min_A + rise_max_A) * 0.5;
+	RFLOAT twist_avg_deg = (twist_min_deg + twist_max_deg) * 0.5;
 
 	// Check helical twist and rise
 	if (verboseOutput)
@@ -945,7 +945,7 @@ void imposeHelicalSymmetryInRealSpace(
 
 	// Crop the central slices
 	v.setXmippOrigin();
-	z_max = ((RFLOAT)(Zdim)) * z_percentage / 2.;
+	z_max = (((RFLOAT)(Zdim)) * z_percentage) * 0.5;
 	if (z_max > (((RFLOAT)(FINISHINGZ(v))) - 1.))
 		z_max = (((RFLOAT)(FINISHINGZ(v))) - 1.);
 	z_min = -z_max;
@@ -1340,7 +1340,7 @@ void cutZCentralPartOfSoftMask(
 	if (cosine_width < 0.001)
 		REPORT_ERROR("helix.cpp::cutZCentralPartOfSoftMask(): Cosine width for soft edge should larger than 0!");
 
-	idz_e = ((RFLOAT)(Zdim)) * z_percentage / 2.;
+	idz_e = (((RFLOAT)(Zdim)) * z_percentage) * 0.5;
 	idz_s = idz_e * (-1.);
 	idz_s_w = idz_s - cosine_width;
 	idz_e_w = idz_e + cosine_width;
@@ -1386,8 +1386,8 @@ void createCylindricalReference(
 			|| (cosine_width < 0.) )
 		REPORT_ERROR("helix.cpp::createCylindricalReference(): Parameter(s) error!");
 
-	inner_radius_pix = inner_diameter_pix / 2.;
-	outer_radius_pix = outer_diameter_pix / 2.;
+	inner_radius_pix = inner_diameter_pix * 0.5;
+	outer_radius_pix = outer_diameter_pix * 0.5;
 
 	v.clear();
 	v.resize(box_size, box_size, box_size);
@@ -1435,10 +1435,10 @@ void createCylindricalReferenceWithPolarity(
 		REPORT_ERROR("helix.cpp::createCylindricalReferenceWithPolarity(): Parameter(s) error!");
 
 	// Set top and bottom radii
-	top_radius_pix = outer_diameter_pix / 2.;
-	bottom_radius_pix = outer_diameter_pix * ratio_topbottom / 2.;
+	top_radius_pix = outer_diameter_pix * 0.5;
+	bottom_radius_pix = (outer_diameter_pix * ratio_topbottom) * 0.5;
 	if (inner_diameter_pix > 0.)
-		bottom_radius_pix = (inner_diameter_pix / 2.) + ratio_topbottom * (outer_diameter_pix / 2. - inner_diameter_pix / 2.);
+		bottom_radius_pix = (inner_diameter_pix * 0.5) + ratio_topbottom * (outer_diameter_pix * 0.5 - inner_diameter_pix * 0.5);
 
 	v.clear();
 	v.resize(box_size, box_size, box_size);
@@ -1446,7 +1446,7 @@ void createCylindricalReferenceWithPolarity(
 
 	r_min = r_max = -1.;
 	if (inner_diameter_pix > 0.)
-		r_min = inner_diameter_pix / 2.;
+		r_min = inner_diameter_pix * 0.5;
     for (long int k=STARTINGZ(v); k<=FINISHINGZ(v); k++)
     {
     	r_max = top_radius_pix - (top_radius_pix - bottom_radius_pix) * ((RFLOAT)(k - STARTINGZ(v))) / ((RFLOAT)(box_size));
@@ -1736,8 +1736,8 @@ void applySoftSphericalMask(
 	//if (cosine_width > 0.05 * r_max)
 	//	r_max -= 2. * cosine_width;
 	//r_max *= 0.45;
-	if ( (sphere_diameter > 0.01) && ((sphere_diameter / 2.) < r_max) )
-		r_max = sphere_diameter / 2.;
+	if ( (sphere_diameter > 0.01) && ((sphere_diameter * 0.5) < r_max) )
+		r_max = sphere_diameter * 0.5;
 	r_max_edge = r_max + cosine_width;
 
 	FOR_ALL_ELEMENTS_IN_ARRAY3D(v)
@@ -1828,7 +1828,7 @@ void convertHelicalTubeCoordsToMetaDataTable(
     if (fn_in.getExtension() != "star")
     	REPORT_ERROR("helix.cpp::convertHelicalTubeCoordsToMetaDataTable(): MetadataTable should have .star extension. Error(s) in " + fn_in);
 
-    half_box_size_pix = box_size_pix / 2.;
+    half_box_size_pix = box_size_pix * 0.5;
     psi_prior_flip_ratio = UNIMODAL_PSI_PRIOR_FLIP_RATIO;
     if (bimodal_angular_priors)
     {
@@ -1927,8 +1927,8 @@ void convertHelicalTubeCoordsToMetaDataTable(
     	if (!cut_into_segments)
     	{
 			MD_out.addObject();
-	    	MD_out.setValue(EMDL_IMAGE_COORD_X, ((x1 + x2) / 2.));
-	    	MD_out.setValue(EMDL_IMAGE_COORD_Y, ((y1 + y2) / 2.));
+	    	MD_out.setValue(EMDL_IMAGE_COORD_X, ((x1 + x2) * 0.5));
+	    	MD_out.setValue(EMDL_IMAGE_COORD_Y, ((y1 + y2) * 0.5));
 	    	MD_out.setValue(EMDL_PARTICLE_HELICAL_TUBE_ID, (tube_id + 1));
 	    	MD_out.setValue(EMDL_ORIENT_TILT_PRIOR, 90.);
 	    	MD_out.setValue(EMDL_ORIENT_PSI_PRIOR, -psi_deg);
@@ -2320,7 +2320,7 @@ void convertHelicalSegmentCoordsToMetaDataTable(
 		REPORT_ERROR("helix.cpp::convertHelicalSegmentCoordsToMetaDataTable(): Wrong dimensions or box size!");
 
 	RFLOAT x = 0., y = 0., z = 0.;
-	RFLOAT half_box_size_pix = box_size_pix / 2.;
+	RFLOAT half_box_size_pix = box_size_pix * 0.5;
 	RFLOAT psi_prior_flip_ratio = UNIMODAL_PSI_PRIOR_FLIP_RATIO;
 	if (bimodal_angular_priors)
 	{
@@ -2404,7 +2404,7 @@ void convertXimdispHelicalSegmentCoordsToMetaDataTable(
     MD_out.addLabel(EMDL_PARTICLE_HELICAL_TRACK_LENGTH_ANGSTROM);
     MD_out.addLabel(EMDL_ORIENT_PSI_PRIOR_FLIP_RATIO);
 
-    half_box_size_pix = box_size_pix / 2.;
+    half_box_size_pix = box_size_pix * 0.5;
     psi_prior_flip_ratio = UNIMODAL_PSI_PRIOR_FLIP_RATIO;
     if (bimodal_angular_priors)
     {
@@ -2519,7 +2519,7 @@ void convertXimdispHelicalTubeCoordsToMetaDataTable(
 
 	x.resize(4);
 	y.resize(4);
-	half_box_size_pix = box_size_pix / 2.;
+	half_box_size_pix = box_size_pix * 0.5;
     psi_prior_flip_ratio = UNIMODAL_PSI_PRIOR_FLIP_RATIO;
     if (bimodal_angular_priors)
     {
@@ -2557,10 +2557,10 @@ void convertXimdispHelicalTubeCoordsToMetaDataTable(
 		getline(fin, line, '\n');
 
 		// Calculate starting and end points for this helical tube
-		x1 = (x[0] + x[1]) / 2.;
-		y1 = (y[0] + y[1]) / 2.;
-		x2 = (x[2] + x[3]) / 2.;
-		y2 = (y[2] + y[3]) / 2.;
+		x1 = (x[0] + x[1]) * 0.5;
+		y1 = (y[0] + y[1]) * 0.5;
+		x2 = (x[2] + x[3]) * 0.5;
+		y2 = (y[2] + y[3]) * 0.5;
 		psi_rad = atan2(y2 - y1, x2 - x1);
 		psi_deg = RAD2DEG(psi_rad);
 		dx = step_pix * cos(psi_rad);
@@ -2569,8 +2569,8 @@ void convertXimdispHelicalTubeCoordsToMetaDataTable(
 		if (!cut_into_segments)
 		{
 			MD_out.addObject();
-	    	MD_out.setValue(EMDL_IMAGE_COORD_X, ((x1 + x2) / 2.));
-	    	MD_out.setValue(EMDL_IMAGE_COORD_Y, ((y1 + y2) / 2.));
+	    	MD_out.setValue(EMDL_IMAGE_COORD_X, ((x1 + x2) * 0.5));
+	    	MD_out.setValue(EMDL_IMAGE_COORD_Y, ((y1 + y2) * 0.5));
 	    	MD_out.setValue(EMDL_PARTICLE_HELICAL_TUBE_ID, nr_tubes);
 	    	MD_out.setValue(EMDL_ORIENT_TILT_PRIOR, 90.);
 	    	MD_out.setValue(EMDL_ORIENT_PSI_PRIOR, -psi_deg);
@@ -2660,7 +2660,7 @@ void convertEmanHelicalSegmentCoordsToMetaDataTable(
     MD_out.addLabel(EMDL_PARTICLE_HELICAL_TRACK_LENGTH_ANGSTROM);
     MD_out.addLabel(EMDL_ORIENT_PSI_PRIOR_FLIP_RATIO);
 
-    half_box_size_pix = box_size_pix / 2.;
+    half_box_size_pix = box_size_pix * 0.5;
     psi_prior_flip_ratio = UNIMODAL_PSI_PRIOR_FLIP_RATIO;
     if (bimodal_angular_priors)
 	{
@@ -2784,7 +2784,7 @@ void convertEmanHelicalTubeCoordsToMetaDataTable(
     MD_out.addLabel(EMDL_PARTICLE_HELICAL_TRACK_LENGTH_ANGSTROM);
     MD_out.addLabel(EMDL_ORIENT_PSI_PRIOR_FLIP_RATIO);
 
-	half_box_size_pix = box_size_pix / 2.;
+	half_box_size_pix = box_size_pix * 0.5;
     psi_prior_flip_ratio = UNIMODAL_PSI_PRIOR_FLIP_RATIO;
     if (bimodal_angular_priors)
     {
@@ -2817,8 +2817,8 @@ void convertEmanHelicalTubeCoordsToMetaDataTable(
 		tag = textToInteger(words[4]);
 		if ( (tag != (-1)) || (fabs(width1 - width2) > 0.01) )
 			REPORT_ERROR("helix.cpp::convertEmanHelicalTubeCoordsToMetaDataTable(): Invalid input file " + fn_in);
-		x1 += width1 / 2.;
-		y1 += width1 / 2.;
+		x1 += width1 * 0.5;
+		y1 += width1 * 0.5;
 
 		// Get x2, y2
 		line.clear();
@@ -2834,8 +2834,8 @@ void convertEmanHelicalTubeCoordsToMetaDataTable(
 		tag = textToInteger(words[4]);
 		if ( (tag != (-2)) || (fabs(width3 - width4) > 0.01) || (fabs(width3 - width1) > 0.01) )
 			REPORT_ERROR("helix.cpp::convertEmanHelicalTubeCoordsToMetaDataTable(): Invalid input file " + fn_in);
-		x2 += width3 / 2.;
-		y2 += width3 / 2.;
+		x2 += width3 * 0.5;
+		y2 += width3 * 0.5;
 
 		nr_tubes++;
 
@@ -2846,16 +2846,16 @@ void convertEmanHelicalTubeCoordsToMetaDataTable(
 
 		// Truncate both ends of the helical tube
 		RFLOAT trans_offset = 0.;
-		x1 += ((width1 / 2.) - trans_offset) * cos(psi_rad);
-		y1 += ((width1 / 2.) - trans_offset) * sin(psi_rad);
-		x2 -= ((width1 / 2.) - trans_offset) * cos(psi_rad);
-		y2 -= ((width1 / 2.) - trans_offset) * sin(psi_rad);
+		x1 += ((width1 * 0.5) - trans_offset) * cos(psi_rad);
+		y1 += ((width1 * 0.5) - trans_offset) * sin(psi_rad);
+		x2 -= ((width1 * 0.5) - trans_offset) * cos(psi_rad);
+		y2 -= ((width1 * 0.5) - trans_offset) * sin(psi_rad);
 
 		if (!cut_into_segments)
 		{
 			MD_out.addObject();
-	    	MD_out.setValue(EMDL_IMAGE_COORD_X, ((x1 + x2) / 2.));
-	    	MD_out.setValue(EMDL_IMAGE_COORD_Y, ((y1 + y2) / 2.));
+	    	MD_out.setValue(EMDL_IMAGE_COORD_X, ((x1 + x2) * 0.5));
+	    	MD_out.setValue(EMDL_IMAGE_COORD_Y, ((y1 + y2) * 0.5));
 	    	MD_out.setValue(EMDL_PARTICLE_HELICAL_TUBE_ID, nr_tubes);
 	    	MD_out.setValue(EMDL_ORIENT_TILT_PRIOR, 90.);
 	    	MD_out.setValue(EMDL_ORIENT_PSI_PRIOR, -psi_deg);
@@ -3068,8 +3068,8 @@ void makeHelicalReference2D(
 	if ( (tube_diameter_pix < 1.) || (tube_diameter_pix > particle_diameter_pix) )
 		REPORT_ERROR("helix.cpp::makeHelicalReference2D(): Invalid tube diameter!");
 
-	r2 = (particle_diameter_pix / 2.) * (particle_diameter_pix / 2.);
-	t2 = (tube_diameter_pix / 2.) * (tube_diameter_pix / 2.);
+	r2 = (particle_diameter_pix * 0.5) * (particle_diameter_pix * 0.5);
+	t2 = (tube_diameter_pix * 0.5) * (tube_diameter_pix * 0.5);
 
 	out.clear();
 	out.resize(box_size, box_size);
@@ -3245,8 +3245,8 @@ void makeHelicalReference3DWithPolarity(
 	rise_pix = rise_A / pixel_size_A;
 	tube_diameter_pix = tube_diameter_A / pixel_size_A;
 	particle_diameter_pix = particle_diameter_A / pixel_size_A;
-	particle_radius_pix = particle_diameter_pix / 2.;
-	particle_radius_max_pix = (CEIL(particle_diameter_pix / 2.)) + 1;
+	particle_radius_pix = particle_diameter_pix * 0.5;
+	particle_radius_max_pix = (CEIL(particle_diameter_pix * 0.5)) + 1;
 	top_radius_pix = cyl_radius_pix = 0.5 * cyl_diameter_A / pixel_size_A;
 	bottom_radius_pix = top_radius_pix * topbottom_ratio;
 
@@ -3267,8 +3267,8 @@ void makeHelicalReference3DWithPolarity(
 	//y0 = 0.;
 	// NEW - To generate references with Dn symmetry. TODO: Am I doing what I want?
 	z0 = rise_pix * FLOOR((RFLOAT)(FIRST_XMIPP_INDEX(box_size)) / rise_pix);
-	x0 = (tube_diameter_pix / 2.) * cos( (PI * twist_deg * z0) / (rise_pix * 180.) );
-	y0 = (tube_diameter_pix / 2.) * sin( (PI * twist_deg * z0) / (rise_pix * 180.) );
+	x0 = (tube_diameter_pix * 0.5) * cos( (PI * twist_deg * z0) / (rise_pix * 180.) );
+	y0 = (tube_diameter_pix * 0.5) * sin( (PI * twist_deg * z0) / (rise_pix * 180.) );
 	vec0.clear();
 	vec0.resize(2);
 	XX(vec0) = x0;
@@ -3304,7 +3304,7 @@ void makeHelicalReference3DWithPolarity(
 
 			for (int dz = -particle_radius_max_pix; dz <= particle_radius_max_pix; dz++)
 			{
-				RFLOAT thres_xy = (top_radius_pix - bottom_radius_pix) * 0.5 * dz / particle_radius_pix + (top_radius_pix + bottom_radius_pix) / 2.;
+				RFLOAT thres_xy = (top_radius_pix - bottom_radius_pix) * 0.5 * dz / particle_radius_pix + (top_radius_pix + bottom_radius_pix) * 0.5;
 				for (int dy = -particle_radius_max_pix; dy <= particle_radius_max_pix; dy++)
 				{
 					for (int dx = -particle_radius_max_pix; dx <= particle_radius_max_pix; dx++)
@@ -3364,13 +3364,13 @@ void makeHelicalReference3DWithPolarity(
 			{
 				x1 *= (tube_diameter_pix + particle_diameter_pix) / tube_diameter_pix;
 				y1 *= (tube_diameter_pix + particle_diameter_pix) / tube_diameter_pix;
-				z1 += particle_diameter_pix / 2.;
+				z1 += particle_diameter_pix * 0.5;
 
-				for (int dz = -particle_radius_max_pix / 2.; dz <= particle_radius_max_pix / 2.; dz++)
+				for (int dz = -particle_radius_max_pix * 0.5; dz <= particle_radius_max_pix * 0.5; dz++)
 				{
-					for (int dy = -particle_radius_max_pix / 2.; dy <= particle_radius_max_pix / 2.; dy++)
+					for (int dy = -particle_radius_max_pix * 0.5; dy <= particle_radius_max_pix * 0.5; dy++)
 					{
-						for (int dx = -particle_radius_max_pix / 2.; dx <= particle_radius_max_pix / 2.; dx++)
+						for (int dx = -particle_radius_max_pix * 0.5; dx <= particle_radius_max_pix * 0.5; dx++)
 						{
 							RFLOAT _x, _y, _z, dist, val_old, val_new;
 							int x2, y2, z2;
@@ -3389,7 +3389,7 @@ void makeHelicalReference3DWithPolarity(
 							_z = (RFLOAT)(z2) - z1;
 
 							dist = sqrt(_x * _x + _y * _y + _z * _z);
-							if (dist > (particle_radius_pix / 2.))
+							if (dist > (particle_radius_pix * 0.5))
 								continue;
 
 							val_old = A3D_ELEM(out, z2, y2, x2);
@@ -3855,8 +3855,8 @@ void outputHelicalSymmetryStatus(
 
 	if (do_split_random_halves)
 	{
-		RFLOAT twist_avg_deg = (twist_deg_half1 + twist_deg_half2) / 2.;
-		RFLOAT rise_avg_A = (rise_A_half1 + rise_A_half2) / 2.;
+		RFLOAT twist_avg_deg = (twist_deg_half1 + twist_deg_half2) * 0.5;
+		RFLOAT rise_avg_A = (rise_A_half1 + rise_A_half2) * 0.5;
 
 		// TODO: raise a warning if two sets of helical parameters are >1% apart?
 		out << " (Half 1) Refined helical twist = " << twist_deg_half1 << " degrees, rise = " << rise_A_half1 << " Angstroms." << std::endl;
@@ -3975,7 +3975,7 @@ void cutOutPartOfHelix(
     for (long int zi = 0; zi < ZSIZE(vout); zi++)
     {
     	// Z subscript is out of range
-    	if ( ((RFLOAT)(ABS(zi + new_z0)) / (RFLOAT)(ZSIZE(vin))) > (z_percentage / 2.) )
+    	if ( ((RFLOAT)(ABS(zi + new_z0)) / (RFLOAT)(ZSIZE(vin))) > (z_percentage * 0.5) )
     		continue;
 
     	// Loop over X and Y
@@ -3986,7 +3986,7 @@ void cutOutPartOfHelix(
         		RFLOAT deg = (180.) * atan2((double)(yi), (double)(xi)) / PI;
 
         		// X or Y subscripts is out of range
-        		if ( (ang_deg < 90.) && ( (deg < ((45.) - (ang_deg / 2.))) || (deg > ((45.) + (ang_deg / 2.))) ) )
+        		if ( (ang_deg < 90.) && ( (deg < ((45.) - (ang_deg * 0.5))) || (deg > ((45.) + (ang_deg * 0.5))) ) )
         			continue;
         		if ( (yi >= old_ymax) || (xi >= old_xmax) )
         			continue;
@@ -4881,10 +4881,10 @@ RFLOAT HermiteInterpolate1D(
 
 	mu2 = mu * mu;
 	mu3 = mu2 * mu;
-	m0  = (y1 - y0) * (1. + bias) * (1. - tension) / 2.;
-	m0 += (y2 - y1) * (1. - bias) * (1. - tension) / 2.;
-	m1  = (y2 - y1) * (1. + bias) * (1. - tension) / 2.;
-	m1 += (y3 - y2) * (1. - bias) * (1. - tension) / 2.;
+	m0  = (y1 - y0) * (1. + bias) * (1. - tension) * 0.5;
+	m0 += (y2 - y1) * (1. - bias) * (1. - tension) * 0.5;
+	m1  = (y2 - y1) * (1. + bias) * (1. - tension) * 0.5;
+	m1 += (y3 - y2) * (1. - bias) * (1. - tension) * 0.5;
 	a0  = 2. * mu3 - 3. * mu2 + 1.;
 	a1  = mu3 - 2. * mu2 + mu;
 	a2  = mu3 - mu2;
@@ -4909,7 +4909,7 @@ void HermiteInterpolateOne3DHelicalFilament(
 {
 	RFLOAT x0, x1, x2, x3, xa, xb, y0, y1, y2, y3, ya, yb, z0, z1, z2, z3, za, zb, mu1, mu2;
 	RFLOAT step_pix, chord_pix, accu_len_pix, present_len_pix, len_pix, psi_prior_flip_ratio, tilt_deg, psi_deg;
-    RFLOAT half_box_size_pix = box_size_pix / 2.;
+    RFLOAT half_box_size_pix = box_size_pix * 0.5;
 	int nr_partitions, nr_segments;
 	std::vector<RFLOAT> xlist, ylist, zlist;
 	Matrix1D<RFLOAT> dr;
@@ -4971,7 +4971,7 @@ void HermiteInterpolateOne3DHelicalFilament(
         // Step size for interpolation is smaller than 1% of the inter-box distance
         // sqrt(0.57735 * 0.57735 * 0.57735 * 3) = 1.0, step size is larger than 1 pixel
     	// TODO: 1% ? Too expensive computationally? Try 10% ?
-        step_pix = (interbox_pix < 57.735) ? (0.57735) : (interbox_pix / 100.); // 1%
+        step_pix = (interbox_pix < 57.735) ? (0.57735) : (interbox_pix * 0.01); // 1%
         //step_pix = (interbox_pix < 5.7735) ? (0.57735) : (interbox_pix / 10.); // 10%
 
     	// Collect points 0, 1, 2, 3 for interpolations
@@ -5395,9 +5395,9 @@ void Interpolate3DCurves(
 			}
 			// Middle points of each short line segment
 			MD_in.addObject();
-			MD_in.setValue(EMDL_IMAGE_COORD_X, (xlist[id] + xlist[id - 1]) / 2.);
-	    	MD_in.setValue(EMDL_IMAGE_COORD_Y, (ylist[id] + ylist[id - 1]) / 2.);
-	    	MD_in.setValue(EMDL_IMAGE_COORD_Z, (zlist[id] + zlist[id - 1]) / 2.);
+			MD_in.setValue(EMDL_IMAGE_COORD_X, (xlist[id] + xlist[id - 1]) * 0.5);
+	    	MD_in.setValue(EMDL_IMAGE_COORD_Y, (ylist[id] + ylist[id - 1]) * 0.5);
+	    	MD_in.setValue(EMDL_IMAGE_COORD_Z, (zlist[id] + zlist[id - 1]) * 0.5);
 	    	if (id == (xlist.size() - 1)) // End point
 	    	{
 				MD_in.addObject();

--- a/src/jaz/tomography/programs/reconstruct_tomogram.cpp
+++ b/src/jaz/tomography/programs/reconstruct_tomogram.cpp
@@ -124,6 +124,15 @@ void TomoBackprojectProgram::initialise(bool verbose)
 
     tomoIndexTodo.clear();
 
+    // If we do a tilt angle offset, apply to all tomograms to prevent trouble with MPI parallelisation
+    if (fabs(tiltAngleOffset) > 0.)
+    {
+        for (int idx = 0; idx < tomogramSet.size(); idx++)
+        {
+            tomogramSet.applyTiltAngleOffset(idx, tiltAngleOffset);
+        }
+    }
+
     if (tomoName == "*")
     {
         do_multiple = true;
@@ -133,6 +142,7 @@ void TomoBackprojectProgram::initialise(bool verbose)
             if (do_only_unfinished && exists(getOutputFileName(idx,false,false)))
                 continue;
             tomoIndexTodo.push_back(idx);
+
         }
 
         if (outFn[outFn.size()-1] != '/') outFn += '/';
@@ -186,11 +196,6 @@ void TomoBackprojectProgram::run(int rank, int size)
         // Abort through the pipeline_control system
         if (pipeline_control_check_abort_job())
             exit(RELION_EXIT_ABORTED);
-
-        if (fabs(tiltAngleOffset) > 0.)
-        {
-            tomogramSet.applyTiltAngleOffset(idx, tiltAngleOffset);
-        }
 
         if (fourierInversion)
         {

--- a/src/macros.h
+++ b/src/macros.h
@@ -45,7 +45,7 @@
 #ifndef MACROS_H
 #define MACROS_H
 
-#define RELION_SHORT_VERSION "5.0-beta-4"
+#define RELION_SHORT_VERSION "5.0.0"
 extern const char *g_RELION_VERSION;
 
 #include <math.h>

--- a/src/metadata_table.cpp
+++ b/src/metadata_table.cpp
@@ -1822,6 +1822,9 @@ void compareMetaDataTable(MetaDataTable &MD1, MetaDataTable &MD2,
 	MDboth.clear();
 	MDonly1.clear();
 	MDonly2.clear();
+    MDboth.setName(MD1.getName());
+    MDonly1.setName(MD1.getName());
+    MDonly2.setName(MD1.getName());
 
 	std::string mystr1, mystr2;
 	long int myint1, myint2;

--- a/src/metadata_table.cpp
+++ b/src/metadata_table.cpp
@@ -2036,6 +2036,7 @@ MetaDataTable subsetMetaDataTable(MetaDataTable &MDin, EMDLabel label, RFLOAT mi
 		REPORT_ERROR("subsetMetadataTable ERROR: input MetaDataTable does not contain label: " +  EMDL::label2Str(label));
 
 	MetaDataTable MDout;
+    MDout.setName(MDin.getName());
 	FOR_ALL_OBJECTS_IN_METADATA_TABLE(MDin)
 	{
 		bool do_include = false;
@@ -2186,7 +2187,9 @@ MetaDataTable removeDuplicatedParticles(MetaDataTable &MDin, EMDLabel mic_label,
 
 
 	MetaDataTable MDout, MDremoved;
-	long n_removed = 0;
+    MDout.setName(MDin.getName());
+    MDremoved.setName(MDin.getName());
+    long n_removed = 0;
 	FOR_ALL_OBJECTS_IN_METADATA_TABLE(MDin)
 	{
 		if (valid[current_object])

--- a/src/ml_optimiser.cpp
+++ b/src/ml_optimiser.cpp
@@ -1878,7 +1878,7 @@ void MlOptimiser::initialiseGeneral(int rank)
 			std::vector<std::string> resols;
 			std::vector<RFLOAT> resols_end, resols_start;
 
-			int nresols = splitString(helical_fourier_mask_resols, ",", resols);
+			splitString(helical_fourier_mask_resols, ",", resols);
 			if (resols.size()%2 == 1) REPORT_ERROR("Provide an even number of start-end resolutions for --fourier_exclude_resols");
 			for (int nshell = 0; nshell < resols.size()/2; nshell++)
 			{

--- a/src/ml_optimiser.cpp
+++ b/src/ml_optimiser.cpp
@@ -2196,7 +2196,7 @@ void MlOptimiser::initialiseGeneral(int rank)
             std::vector<std::string> resols;
             std::vector<RFLOAT> resols_end, resols_start;
 
-            int nresols = splitString(helical_fourier_mask_resols, ",", resols);
+            splitString(helical_fourier_mask_resols, ",", resols);
             if (resols.size()%2 == 1) REPORT_ERROR("Provide an even number of start-end resolutions for --fourier_exclude_resols");
             for (int nshell = 0; nshell < resols.size()/2; nshell++)
             {

--- a/src/ml_optimiser.cpp
+++ b/src/ml_optimiser.cpp
@@ -2035,7 +2035,7 @@ void MlOptimiser::initialiseGeneral(int rank)
     {
         blush_args += " --gpu ";
         for (auto &d : gpuDevices)
-            blush_args += d + ",";
+            blush_args += integerToString(d) + ",";
         blush_args += " ";
     }
     else

--- a/src/ml_optimiser.cpp
+++ b/src/ml_optimiser.cpp
@@ -2035,7 +2035,7 @@ void MlOptimiser::initialiseGeneral(int rank)
     {
         blush_args += " --gpu ";
         for (auto &d : gpuDevices)
-            blush_args += gpu_ids + ",";
+            blush_args += d + ",";
         blush_args += " ";
     }
     else

--- a/src/motioncorr_runner.cpp
+++ b/src/motioncorr_runner.cpp
@@ -660,35 +660,73 @@ void MotioncorrRunner::getShiftsMotioncor2(FileName fn_log, Micrograph &mic)
 	// Read through the shifts file
 	int frame = first_frame_sum; // 1-indexed
 	bool have_found_final = false;
-	while (getline(in, line, '\n'))
-	{
-	// ignore all commented lines, just read first two lines with data
-		if (line.find("Full-frame alignment shift") != std::string::npos)
-		{
-			have_found_final = true;
+    bool is_version_16 = false;
+
+	while (getline(in, line)) {
+		// Primary check: Detect '-Group' with two valid integers
+		std::size_t pos = line.find("-Group");
+		if (pos != std::string::npos) {
+			std::istringstream ss(line.substr(pos + 6)); // Extract content after '-Group'
+			int group1 = -1, group2 = -1;
+			ss >> group1 >> group2; // Attempt to parse two integers
+
+			if (ss && group1 >= 0 && group2 >= 0) { // Ensure both integers were parsed correctly
+				is_version_16 = true;
+				break; // Exit loop, as version is determined
+			}
 		}
-		else if (have_found_final)
-		{
-			size_t shiftpos = line.find("shift:");
-			if (shiftpos != std::string::npos)
-			{
-				std::vector<std::string> words;
-				tokenize(line.substr(shiftpos+7), words);;
-    				if (words.size() < 2)
-    				{
-    					std::cerr << " fn_log= " << fn_log << std::endl;
-    					REPORT_ERROR("ERROR: unexpected number of words on line from MOTIONCORR logfile: " + line);
-    				}
- 		   		mic.setGlobalShift(frame, textToFloat(words[0]), textToFloat(words[1]));
-				frame++;
-			}
-			else
-			{
-				// Stop now
-				break;
-			}
+
+		// Secondary check: Detect '-InvGain' or '-TiffOrder' parameters
+		if (line.find("-InvGain") != std::string::npos || line.find("-TiffOrder") != std::string::npos) {
+			is_version_16 = true;
+			break; // Exit loop, as version is determined
 		}
 	}
+
+    // Reset stream for parsing content
+    in.clear();
+    in.seekg(0);
+
+    if (is_version_16) {
+        // Parse Full-frame alignment from MotionCor2 1.6
+        while (getline(in, line)) {
+            if (line.find("Frame") != std::string::npos && line.find("x Shift") != std::string::npos) {
+                while (getline(in, line) && !line.empty()) {
+                    std::istringstream ss(line);
+                    int frame;
+                    float x_shift, y_shift;
+                    ss >> frame >> x_shift >> y_shift;
+                    if (ss.fail()) {
+                        std::cerr << "Error: Unexpected line format in 1.6 global shifts: " << line << std::endl;
+                        continue;
+                    }
+                    mic.setGlobalShift(frame, x_shift, y_shift);
+                }
+                break;
+            }
+        }
+    } else {
+        // Parse log format from MotionCor2 1.5
+        while (getline(in, line)) {
+            if (line.find("Full-frame alignment shift") != std::string::npos) {
+                have_found_final = true;
+            } else if (have_found_final) {
+                size_t shiftpos = line.find("shift:");
+                if (shiftpos != std::string::npos) {
+                    std::vector<std::string> words;
+                    tokenize(line.substr(shiftpos + 7), words); // Get shift values after "shift:"
+                    if (words.size() < 2) {
+                        std::cerr << "Error: Unexpected number of words in log: " << line << std::endl;
+                        continue;
+                    }
+                    mic.setGlobalShift(frame, textToFloat(words[0]), textToFloat(words[1]));
+                    frame++;
+                } else {
+                    break; // Stop parsing if shift lines are done
+                }
+            }
+        }
+    }
 	in.close();
 
 	mic.first_frame = first_frame_sum;

--- a/src/motioncorr_runner.cpp
+++ b/src/motioncorr_runner.cpp
@@ -658,9 +658,9 @@ void MotioncorrRunner::getShiftsMotioncor2(FileName fn_log, Micrograph &mic)
 	in.seekg(0);
 
 	// Read through the shifts file
-	int frame = first_frame_sum;
+	int frame = first_frame_sum; // 1-indexed
 	bool have_found_final = false;
-	while (getline(in, line))
+	while (getline(in, line, '\n'))
 	{
 	// ignore all commented lines, just read first two lines with data
 		if (line.find("Full-frame alignment shift") != std::string::npos)
@@ -673,13 +673,13 @@ void MotioncorrRunner::getShiftsMotioncor2(FileName fn_log, Micrograph &mic)
 			if (shiftpos != std::string::npos)
 			{
 				std::vector<std::string> words;
-				tokenize(line.substr(shiftpos + 7), words);
-				if (words.size() < 2)
-				{
-					std::cerr << " fn_log= " << fn_log << std::endl;
-    				REPORT_ERROR("ERROR: unexpected number of words on line from MOTIONCORR logfile: " + line);
-				}
-				mic.setGlobalShift(frame, textToFloat(words[0]), textToFloat(words[1]));
+				tokenize(line.substr(shiftpos+7), words);;
+    				if (words.size() < 2)
+    				{
+    					std::cerr << " fn_log= " << fn_log << std::endl;
+    					REPORT_ERROR("ERROR: unexpected number of words on line from MOTIONCORR logfile: " + line);
+    				}
+ 		   		mic.setGlobalShift(frame, textToFloat(words[0]), textToFloat(words[1]));
 				frame++;
 			}
 			else
@@ -709,7 +709,7 @@ void MotioncorrRunner::getShiftsMotioncor2(FileName fn_log, Micrograph &mic)
 					if (ss.fail())
 					{
 						std::cerr << " fn_log= " << fn_log << std::endl;
-    					REPORT_ERROR("Error: Unexpected line format in 1.6 global shifts: " + line);
+						REPORT_ERROR("Error: Unexpected line format in 1.6 global shifts: " + line);
 					}
 					mic.setGlobalShift(frame, x_shift, y_shift);
 				}
@@ -723,8 +723,7 @@ void MotioncorrRunner::getShiftsMotioncor2(FileName fn_log, Micrograph &mic)
 
 	// Read local shifts
 	FileName fn_patch = fn_log.withoutExtension() + "0-Patch-Patch.log";
-	if (!exists(fn_patch))
-	{
+	if (!exists(fn_patch)) {
 		std::cerr << "warning: failed to load local shifts from MotionCor2 logfile, but this does not affect further processing: " << fn_patch << std::endl;
 		return;
 	}
@@ -734,13 +733,11 @@ void MotioncorrRunner::getShiftsMotioncor2(FileName fn_log, Micrograph &mic)
 
 	while (getline(in, line, '\n'))
 	{
-		if (line.find("#") != std::string::npos)
-			continue;
+		if (line.find("#") != std::string::npos) continue;
 
 		std::vector<std::string> words;
 		tokenize(line, words);
-		if (words.size() != 7)
-			continue;
+    		if (words.size() != 7) continue;
 
 		mic.patchZ.push_back(textToFloat(words[0]) + first_frame_sum - 1); // 1-indexed
 		mic.patchX.push_back(textToFloat(words[1]));

--- a/src/pipeline_jobs.cpp
+++ b/src/pipeline_jobs.cpp
@@ -7065,8 +7065,6 @@ void RelionJob::initialiseTomoSubtomoJob()
 	joboptions["do_stack2d"] = JobOption("Write output as 2D stacks?", true ,"If set to Yes, this program will write output subtomograms as 2D substacks. This is new as of relion-4.1, and the preferred way of generating subtomograms. If set to No, then relion-4.0 3D pseudo-subtomograms will be written out. Either can be used in subsequent refinements and classifications.");
 	joboptions["do_float16"] = JobOption("Write output in float16?", true ,"If set to Yes, this program will write output images in float16 MRC format. This will save a factor of two in disk space compared to the default of writing in float32. Note that RELION and CCPEM will read float16 images, but other programs may not (yet) do so.");
 
-    joboptions["do_real_subtomo"] = JobOption("Extract and re-project real subtomograms?", false, "If set to Yes, this program will box out real subtomograms from the input tomogram and then re-project these into 2D stacks that resemble the 2D stacks from windowed tilt series images. The size of the images is determined by the crop size; the pixel size is that of the tomogram. This will result in a particles.star file that is suitable for low-resolution subtomogram averaging and a particles_for_class2d.star file that can be used for fast 2D classification in order to select good particles. You can re-launch the GUI without the --tomo argument to get access to the Class2D job type. If set to No, the program will write out normal windowed tilt-series images that are suitable for high-resolution subtomogram averaging.");
-
 }
 
 bool RelionJob::getCommandsTomoSubtomoJob(std::string &outputname, std::vector<std::string> &commands,
@@ -7120,14 +7118,6 @@ bool RelionJob::getCommandsTomoSubtomoJob(std::string &outputname, std::vector<s
 	{
 		command += " --stack2d ";
 	}
-
-    if (joboptions["do_real_subtomo"].getBoolean())
-    {
-        command += " --real_subtomo ";
-        Node node2(outputname+"particles_for_class2d.star", LABEL_CLASS2D_PARTS);
-        outputNodes.push_back(node2);
-
-    }
 
 	if (is_continue)
 	{

--- a/src/pipeliner.cpp
+++ b/src/pipeliner.cpp
@@ -818,14 +818,14 @@ void PipeLine::runScheduledJobs(FileName fn_sched, FileName fn_jobids, int nr_re
 
 	std::vector<FileName> my_scheduled_processes;
 	std::vector<std::string> jobids;
-	int njobs = splitString(fn_jobids, " ", jobids);
-	if (njobs == 0)
+	splitString(fn_jobids, " ", jobids);
+	if (jobids.size() == 0)
 	{
 		REPORT_ERROR("PipeLine::runScheduledJobs: Nothing to do...");
 	}
 	else
 	{
-		for (int i = 0; i < njobs; i++)
+		for (int i = 0; i < jobids.size(); i++)
 			my_scheduled_processes.push_back(jobids[i]);
 	}
 

--- a/src/pipeliner.cpp
+++ b/src/pipeliner.cpp
@@ -814,14 +814,14 @@ void PipeLine::runScheduledJobs(FileName fn_sched, FileName fn_jobids, int nr_re
 
 	std::vector<FileName> my_scheduled_processes;
 	std::vector<std::string> jobids;
-	int njobs = splitString(fn_jobids, " ", jobids);
-	if (njobs == 0)
+	splitString(fn_jobids, " ", jobids);
+	if (jobids.size() == 0)
 	{
 		REPORT_ERROR("PipeLine::runScheduledJobs: Nothing to do...");
 	}
 	else
 	{
-		for (int i = 0; i < njobs; i++)
+		for (int i = 0; i < jobids.size(); i++)
 			my_scheduled_processes.push_back(jobids[i]);
 	}
 

--- a/src/projector.cpp
+++ b/src/projector.cpp
@@ -24,7 +24,7 @@
 #ifdef _CUDA_ENABLED
 	#include <cufft.h>
 #elif _HIP_ENABLED
-	#include <hipfft.h>
+	#include <hipfft/hipfft.h>
 #endif
 #if defined _CUDA_ENABLED || defined _HIP_ENABLED
 	#include <sys/types.h>

--- a/src/rwTIFF.h
+++ b/src/rwTIFF.h
@@ -40,8 +40,8 @@ int readTIFF(TIFF* ftiff, long int img_select, bool readdata=false, bool isStack
 	long int _nDim;
 
 	// These are libtiff's types.
-	uint32 width, length; // apparent dimensions in the file
-	uint16 sampleFormat, bitsPerSample, resolutionUnit;
+	uint32_t width, length; // apparent dimensions in the file
+	uint16_t sampleFormat, bitsPerSample, resolutionUnit;
 	float xResolution;
 	
 	if (TIFFGetField(ftiff, TIFFTAG_IMAGEWIDTH, &width) != 1 ||
@@ -182,8 +182,8 @@ int readTIFF(TIFF* ftiff, long int img_select, bool readdata=false, bool isStack
 			TIFFSetDirectory(ftiff, img_select);
 
 			// Make sure image property is consistent for all frames
-			uint32 cur_width, cur_length;
-			uint16 cur_sampleFormat, cur_bitsPerSample;
+			uint32_t cur_width, cur_length;
+			uint16_t cur_sampleFormat, cur_bitsPerSample;
 
 			if (TIFFGetField(ftiff, TIFFTAG_IMAGEWIDTH, &cur_width) != 1 ||
 			    TIFFGetField(ftiff, TIFFTAG_IMAGELENGTH, &cur_length) != 1)

--- a/src/schemer.cpp
+++ b/src/schemer.cpp
@@ -186,7 +186,7 @@ void  SchemerOperator::readFromStarFile() const
 	// The localtion is always in input1
 	mystring = schemer_global_strings[input1].value;
 	std::vector< std::string > splits;
-	int nr_splits = splitString(mystring, ",", splits);
+	splitString(mystring, ",", splits);
 	if (splits.size() < 3) REPORT_ERROR("Need at least three comma-separated values for starfilename, tablename and labelname");
 	mystarfile = splits[0];
 	mytable = splits[1];
@@ -396,7 +396,7 @@ bool SchemerOperator::performOperation() const
 		else
 		{
 			std::vector< std::string > splits;
-			int nr_splits = splitString(schemer_global_strings[input1].value, ",", splits);
+			splitString(schemer_global_strings[input1].value, ",", splits);
 			schemer_global_floats[output].value = splits.size();
 		}
 	}
@@ -446,7 +446,7 @@ bool SchemerOperator::performOperation() const
 	{
 
 		std::vector< std::string > splits;
-		int nr_splits = splitString(schemer_global_strings[input1].value, ",", splits);
+		splitString(schemer_global_strings[input1].value, ",", splits);
 		int mypos = ROUND(val2);
 		// for negative Ns, count from the back
 		if (mypos < 0) mypos = splits.size() - mypos + 1;
@@ -1712,7 +1712,7 @@ RelionJob Scheme::prepareJob(FileName current_node)
 				FileName before = mystring.beforeFirstOf("$$");
 				FileName after = mystring.afterFirstOf("$$");
 				std::vector< std::string > splits;
-				int nr_splits = splitString(after, " ", splits);
+				splitString(after, " ", splits);
 				if (splits.size() == 0)
 				{
 					REPORT_ERROR(" ERROR: cannot find anything after $$ sign in string: " + mystring);

--- a/src/schemer.cpp
+++ b/src/schemer.cpp
@@ -186,7 +186,7 @@ void  SchemerOperator::readFromStarFile() const
 	// The localtion is always in input1
 	mystring = schemer_global_strings[input1].value;
 	std::vector< std::string > splits;
-	int nr_splits = splitString(mystring, ",", splits);
+	splitString(mystring, ",", splits);
 	if (splits.size() < 3) REPORT_ERROR("Need at least three comma-separated values for starfilename, tablename and labelname");
 	mystarfile = splits[0];
 	mytable = splits[1];
@@ -396,7 +396,7 @@ bool SchemerOperator::performOperation() const
 		else
 		{
 			std::vector< std::string > splits;
-			int nr_splits = splitString(schemer_global_strings[input1].value, ",", splits);
+			splitString(schemer_global_strings[input1].value, ",", splits);
 			schemer_global_floats[output].value = splits.size();
 		}
 	}
@@ -446,7 +446,7 @@ bool SchemerOperator::performOperation() const
 	{
 
 		std::vector< std::string > splits;
-		int nr_splits = splitString(schemer_global_strings[input1].value, ",", splits);
+		splitString(schemer_global_strings[input1].value, ",", splits);
 		int mypos = ROUND(val2);
 		// for negative Ns, count from the back
 		if (mypos < 0) mypos = splits.size() - mypos + 1;
@@ -1711,7 +1711,7 @@ RelionJob Scheme::prepareJob(FileName current_node)
 				FileName before = mystring.beforeFirstOf("$$");
 				FileName after = mystring.afterFirstOf("$$");
 				std::vector< std::string > splits;
-				int nr_splits = splitString(after, " ", splits);
+				splitString(after, " ", splits);
 				if (splits.size() == 0)
 				{
 					REPORT_ERROR(" ERROR: cannot find anything after $$ sign in string: " + mystring);

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -484,10 +484,10 @@ void removeQuotes(char **_str)
 }
 
 // Split a string ==========================================================
-int splitString(const std::string& input,
-                const std::string& delimiter,
-                std::vector< std::string >& results,
-                bool includeEmpties)
+void splitString(const std::string& input,
+                 const std::string& delimiter,
+                 std::vector< std::string >& results,
+                 bool includeEmpties)
 {
 	results.clear();
 	size_t iPos, newPos;
@@ -495,7 +495,7 @@ int splitString(const std::string& input,
 	size_t isize = input.size();
 
 	if (isize == 0 || sizeS2 == 0)
-		return 0;
+		return;
 
 	std::vector<size_t> positions;
 	newPos = input.find(delimiter);
@@ -504,7 +504,7 @@ int splitString(const std::string& input,
 	if (newPos == std::string::npos)
 	{
 		results.push_back(input);
-		return 1;
+		return;
 	}
 
 	int numFound = 0;
@@ -540,7 +540,7 @@ int splitString(const std::string& input,
 		if (includeEmpties || s.size() > 0)
 			results.push_back(s);
 	}
-	return numFound;
+	return;
 }
 
 // To lower ================================================================

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -490,25 +490,25 @@ int splitString(const std::string& input,
                 bool includeEmpties)
 {
 	results.clear();
-	int iPos = 0;
-	int newPos = -1;
-	int sizeS2 = static_cast< int >(delimiter.size());
-	int isize = static_cast< int >(input.size());
+	size_t iPos, newPos;
+	size_t sizeS2 = delimiter.size();
+	size_t isize = input.size();
 
 	if (isize == 0 || sizeS2 == 0)
 		return 0;
 
-	std::vector< int > positions;
-	newPos = input.find(delimiter, 0);
+	std::vector<size_t> positions;
+	newPos = input.find(delimiter);
 
-	if (newPos < 0)
+	// No delimiter
+	if (newPos == std::string::npos)
 	{
 		results.push_back(input);
 		return 1;
 	}
 
 	int numFound = 0;
-	while (newPos >= iPos)
+	while (newPos != std::string::npos)
 	{
 		numFound++;
 		positions.push_back(newPos);
@@ -516,23 +516,27 @@ int splitString(const std::string& input,
 		newPos = input.find(delimiter, iPos + sizeS2);
 	}
 
-	if (numFound == 0)
-		return 0;
-
-	for (int i = 0; i <= static_cast< int >(positions.size()); i++)
+	for (size_t i = 0; i <= numFound; i++)
 	{
-		std::string s("");
+		std::string s;
+
+		// First element; no delimiter at the beginning
 		if (i == 0)
-			s = input.substr(i, positions[i]);
-		int offset = positions[i-1] + sizeS2;
-		if (offset < isize)
 		{
-			if (i == positions.size())
-				s = input.substr(offset);
-			else if (i > 0)
-				s = input.substr(positions[i-1] + sizeS2,
-				                 positions[i] - positions[i-1] - sizeS2);
+			s = input.substr(i, positions[i]);
 		}
+		else
+		{
+			int offset = positions[i - 1] + sizeS2;
+//			std::cout << "i = " << i << " positions[i - 1] = " << positions[i - 1] << " offset = " << offset << std::endl;
+
+			// The last element
+			if (i == numFound)
+				s = input.substr(offset);
+			else
+				s = input.substr(offset, positions[i] - offset);
+		}
+
 		if (includeEmpties || s.size() > 0)
 			results.push_back(s);
 	}

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -486,22 +486,6 @@ std::string removeSpaces(const std::string& _str)
 	return retval;
 }
 
-// Remove quotes ===========================================================
-void removeQuotes(char **_str)
-{
-	std::string retval = *_str;
-	if (retval.length() == 0)
-		return;
-	char c = retval[0];
-	if (c == '\"' || c == '\'')
-		retval = retval.substr(1, retval.length() - 1);
-	c = retval[retval.length()-1];
-	if (c == '\"' || c == '\'')
-		retval = retval.substr(0, retval.length() - 1);
-	free(*_str);
-	*_str = strdup(retval.c_str());
-}
-
 // Split a string ==========================================================
 int splitString(const std::string& input,
                 const std::string& delimiter,

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -509,25 +509,25 @@ int splitString(const std::string& input,
                 bool includeEmpties)
 {
 	results.clear();
-	int iPos = 0;
-	int newPos = -1;
-	int sizeS2 = static_cast< int >(delimiter.size());
-	int isize = static_cast< int >(input.size());
+	size_t iPos, newPos;
+	size_t sizeS2 = delimiter.size();
+	size_t isize = input.size();
 
 	if (isize == 0 || sizeS2 == 0)
 		return 0;
 
-	std::vector< int > positions;
-	newPos = input.find(delimiter, 0);
+	std::vector<size_t> positions;
+	newPos = input.find(delimiter);
 
-	if (newPos < 0)
+	// No delimiter
+	if (newPos == std::string::npos)
 	{
 		results.push_back(input);
 		return 1;
 	}
 
 	int numFound = 0;
-	while (newPos >= iPos)
+	while (newPos != std::string::npos)
 	{
 		numFound++;
 		positions.push_back(newPos);
@@ -535,23 +535,27 @@ int splitString(const std::string& input,
 		newPos = input.find(delimiter, iPos + sizeS2);
 	}
 
-	if (numFound == 0)
-		return 0;
-
-	for (int i = 0; i <= static_cast< int >(positions.size()); i++)
+	for (size_t i = 0; i <= numFound; i++)
 	{
-		std::string s("");
+		std::string s;
+
+		// First element; no delimiter at the beginning
 		if (i == 0)
-			s = input.substr(i, positions[i]);
-		int offset = positions[i-1] + sizeS2;
-		if (offset < isize)
 		{
-			if (i == positions.size())
-				s = input.substr(offset);
-			else if (i > 0)
-				s = input.substr(positions[i-1] + sizeS2,
-				                 positions[i] - positions[i-1] - sizeS2);
+			s = input.substr(i, positions[i]);
 		}
+		else
+		{
+			int offset = positions[i - 1] + sizeS2;
+//			std::cout << "i = " << i << " positions[i - 1] = " << positions[i - 1] << " offset = " << offset << std::endl;
+
+			// The last element
+			if (i == numFound)
+				s = input.substr(offset);
+			else
+				s = input.substr(offset, positions[i] - offset);
+		}
+
 		if (includeEmpties || s.size() > 0)
 			results.push_back(s);
 	}

--- a/src/strings.cpp
+++ b/src/strings.cpp
@@ -503,10 +503,10 @@ void removeQuotes(char **_str)
 }
 
 // Split a string ==========================================================
-int splitString(const std::string& input,
-                const std::string& delimiter,
-                std::vector< std::string >& results,
-                bool includeEmpties)
+void splitString(const std::string& input,
+                 const std::string& delimiter,
+                 std::vector< std::string >& results,
+                 bool includeEmpties)
 {
 	results.clear();
 	size_t iPos, newPos;
@@ -514,7 +514,7 @@ int splitString(const std::string& input,
 	size_t isize = input.size();
 
 	if (isize == 0 || sizeS2 == 0)
-		return 0;
+		return;
 
 	std::vector<size_t> positions;
 	newPos = input.find(delimiter);
@@ -523,7 +523,7 @@ int splitString(const std::string& input,
 	if (newPos == std::string::npos)
 	{
 		results.push_back(input);
-		return 1;
+		return;
 	}
 
 	int numFound = 0;
@@ -559,7 +559,7 @@ int splitString(const std::string& input,
 		if (includeEmpties || s.size() > 0)
 			results.push_back(s);
 	}
-	return numFound;
+	return;
 }
 
 // To lower ================================================================

--- a/src/strings.h
+++ b/src/strings.h
@@ -313,18 +313,6 @@ std::string trim2(const std::string& str);
  * finishing spaces are removed
  */
 std::string removeSpaces(const std::string& _str);
-
-/** Remove quotes.
- *
- * This function removes the first character if it is a RFLOAT or single quote,
- * as well as the last character. The char pointer might be moved.
- *
- * @code
- * char str[10] = "\"Hello\"";
- * (&str);
- * @endcode
- */
-void removeQuotes(char** _str);
 //@}
 
 /** @name Tokenization

--- a/src/strings.h
+++ b/src/strings.h
@@ -358,10 +358,10 @@ void removeQuotes(char** _str);
  *
  * Returns a the number of tokens found. The tokens are in the variable results.
  */
-int splitString(const std::string& input,
-                const std::string& delimiter,
-                std::vector< std::string >& results,
-                bool includeEmpties = false);
+void splitString(const std::string& input,
+                 const std::string& delimiter,
+                 std::vector< std::string >& results,
+                 bool includeEmpties = false);
 
 /** Returns first token (char*).
  *

--- a/src/strings.h
+++ b/src/strings.h
@@ -353,10 +353,10 @@ void removeQuotes(char** _str);
  *
  * Returns a the number of tokens found. The tokens are in the variable results.
  */
-int splitString(const std::string& input,
-                const std::string& delimiter,
-                std::vector< std::string >& results,
-                bool includeEmpties = false);
+void splitString(const std::string& input,
+                 const std::string& delimiter,
+                 std::vector< std::string >& results,
+                 bool includeEmpties = false);
 
 /** Returns first token (char*).
  *

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -112,6 +112,9 @@ void init_progress_bar(long total)
 // routine must be in ascending order, ie, 0, 1, 2, ... No. elements
 void progress_bar(long rlen)
 {
+	if (!isatty(fileno(stdout)))
+		return;
+
 	static time_t startt, prevt;
 	time_t currt;
 	static long totlen;


### PR DESCRIPTION
## Summary

- `progress_bar()` in `src/time.cpp` uses `\r` to animate in-place on a real terminal, but when stdout is captured (AWS Batch container, file redirect), every animation frame is a separate line — flooding logs with hundreds of `~~(,_,">` / `[oo]` lines per progress event
- Class2D, Class3D, Refine3D jobs are worst offenders (many EM iterations × multiple progress events per iteration)
- Fix: `isatty(fileno(stdout))` early return — suppresses all animation output when stdout is not a TTY; interactive terminal users unaffected

## Test plan

- [ ] Run Class2D/Class3D/Refine3D job via CryoCloud and verify CloudWatch logs have zero lines matching `~~(,_,">`
- [ ] Run RELION interactively in a terminal and verify animation still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)